### PR TITLE
Support for MIM SP1 PowerShell

### DIFF
--- a/Solutions/UserProfile.MIMSync/SharePointSync.psm1
+++ b/Solutions/UserProfile.MIMSync/SharePointSync.psm1
@@ -78,8 +78,17 @@ function Install-SharePointSyncConfiguration
 
     $MimPowerShellModuleAssembly = Get-Item -Path (Join-Path (Get-SynchronizationServicePath) UIShell\Microsoft.DirectoryServices.MetadirectoryServices.Config.dll)
     if ($MimPowerShellModuleAssembly.VersionInfo.ProductMajorPart -eq 4 -and
-        $MimPowerShellModuleAssembly.VersionInfo.ProductMinorPart -eq 3 -and 
-        $MimPowerShellModuleAssembly.VersionInfo.ProductBuildPart -ge 2064)
+    	(
+		(
+		$MimPowerShellModuleAssembly.VersionInfo.ProductMinorPart -eq 3 -and 
+		$MimPowerShellModuleAssembly.VersionInfo.ProductBuildPart -ge 2064
+		) -or
+		(
+		$MimPowerShellModuleAssembly.VersionInfo.ProductMinorPart -eq 4 -and 
+		$MimPowerShellModuleAssembly.VersionInfo.ProductBuildPart -ge 1237
+		)
+	 )
+	)
     {
         Write-Verbose "Sufficient MIM PowerShell version detected (>= 4.3.2064): $($MimPowerShellModuleAssembly.VersionInfo.ProductVersion)"
     }


### PR DESCRIPTION
The new version of the MIM PowerShell (SP1) is 4.4.1237 - therefore the comparison fails. This change addresses this issue.