### PR TITLE
Support for multiple AD Management Agents

### DIFF
--- a/Solutions/UserProfile.MIMSync/SharePointSync.psm1
+++ b/Solutions/UserProfile.MIMSync/SharePointSync.psm1
@@ -211,21 +211,29 @@ function Start-SharePointSync
     (
         # Turn on Delta operations for the management agents
         [Switch]
-        $Delta
+        $Delta,
+        # Specify the name of an AD Management Agent
+        [String]
+        $ADMAName
     )
+
+    # If no AD Management Agent is specified, use the standard one (ADMA)
+    if (!($ADMAName)) {
+        $ADMAName = "ADMA"
+    }
 
 ### Run the connectors
 if ($Delta)
 {
-    Start-ManagementAgent -Name ADMA -RunProfile DELTAIMPORT
-    Start-ManagementAgent -Name ADMA -RunProfile DELTASYNC
+    Start-ManagementAgent -Name $ADMAName -RunProfile DELTAIMPORT
+    Start-ManagementAgent -Name $ADMAName -RunProfile DELTASYNC
     Start-ManagementAgent -Name SPMA -RunProfile DELTAIMPORT
     Start-ManagementAgent -Name SPMA -RunProfile DELTASYNC
 }
 else
 {
-    Start-ManagementAgent -Name ADMA -RunProfile FULLIMPORT
-    Start-ManagementAgent -Name ADMA -RunProfile FULLSYNC
+    Start-ManagementAgent -Name $ADMAName -RunProfile FULLIMPORT
+    Start-ManagementAgent -Name $ADMAName -RunProfile FULLSYNC
     Start-ManagementAgent -Name SPMA -RunProfile FULLIMPORT
     Start-ManagementAgent -Name SPMA -RunProfile FULLSYNC
 }


### PR DESCRIPTION
Added the ability to specify the name of the AD Management Agent you want to run. By default, only the AD Management Agent that was created by this module (named "ADMA") can be started, but you may have multiple ones - e.g. in a multi-forest scenario. This small change does not alter the creation process of the default AD Management Agent, it only adds a parameter to the SharePointSync function to be able to start other Management Agents with a different name. When no name is specified, the original "ADMA" management agent will be run.