### PR TITLE
Update nav querySelector to target dynamic-children that re NOT links

### DIFF
--- a/Solutions/SharePoint.UI.Responsive/SP-Responsive-UI.js
+++ b/Solutions/SharePoint.UI.Responsive/SP-Responsive-UI.js
@@ -200,7 +200,7 @@ PnPResponsiveApp.Main = (function () {
             topNavClone.className = topNavClone.className + ' mobile-only';
             topNavClone = cloneSPIdNodes(topNavClone);
             /* Sub nodes accordion */
-            var childs = topNavClone.querySelectorAll('a.dynamic-children');
+            var childs = topNavClone.querySelectorAll('.dynamic-children.menu-item');
             for (var c = 0; c < childs.length; c++) {
                 /* Add button to preserve html link */
                 var expandBtn = document.createElement('button');


### PR DESCRIPTION

When using Folder based structural navigation or Taxonomy navigation with a parent node that is not associated to a page, SharePoint would render as an </span> element instead of <a/>